### PR TITLE
Kontent RC1 + Statiq Beta 20

### DIFF
--- a/Kontent.Statiq.Tests/Kontent.Statiq.Tests.csproj
+++ b/Kontent.Statiq.Tests/Kontent.Statiq.Tests.csproj
@@ -12,9 +12,9 @@
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
-    <PackageReference Include="Statiq.Core" Version="1.0.0-beta.17" />
-    <PackageReference Include="Statiq.Razor" Version="1.0.0-beta.17" />
-    <PackageReference Include="Statiq.Testing" Version="1.0.0-beta.17" />
+    <PackageReference Include="Statiq.Core" Version="1.0.0-beta.20" />
+    <PackageReference Include="Statiq.Razor" Version="1.0.0-beta.20" />
+    <PackageReference Include="Statiq.Testing" Version="1.0.0-beta.20" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>

--- a/Kontent.Statiq.Tests/PipelineExecutionHelpers.cs
+++ b/Kontent.Statiq.Tests/PipelineExecutionHelpers.cs
@@ -29,7 +29,7 @@ namespace Kontent.Statiq.Tests
             var responseJsonPath = Path.Combine(Environment.CurrentDirectory, $"response{Path.DirectorySeparatorChar}getitems.json");
             var responseJson = File.ReadAllText(responseJsonPath);
             return new Kontent<Article>(MockDeliveryClient.Create(responseJson, cfg => cfg.WithTypeProvider(new CustomTypeProvider())))
-                .WithContent(item => item.Title); // TODO : see if we can map rich content into a flat string
+                .WithContent(item => item.Title);
         }
     }
 }

--- a/Kontent.Statiq.Tests/When_processing_images.cs
+++ b/Kontent.Statiq.Tests/When_processing_images.cs
@@ -1,4 +1,5 @@
 ﻿using FluentAssertions;
+using Statiq.Common;
 using Statiq.Testing;
 using System.Threading.Tasks;
 using Xunit;
@@ -41,6 +42,7 @@ namespace Kontent.Statiq.Tests
             var document = new TestDocument(content);
 
             // When
+            
             var assetParser = new KontentImageProcessor().WithLocalPath("/assets/img");
             var output = await ExecuteAsync(new[] { document }, assetParser);
 
@@ -52,18 +54,23 @@ namespace Kontent.Statiq.Tests
         }
 
         [Theory,
-         InlineData("<meta property=\"og:image\" content=\"https://the.cms/images/image1.jpg\"/>", "/assets/img/image1.jpg")
+         InlineData("<meta property=\"og:image\" content=\"https://the.cms/images/image1.jpg\"/>", "", "/assets/img/image1.jpg"),
+         InlineData("<meta property=\"og:image\" content=\"https://the.cms/images/image1.jpg\"/>", "test.alanta.nl", "https://test.alanta.nl/assets/img/image1.jpg")
          ]
-        public async Task It_should_replace_meta_url_with_local_path(string tag, string localUrl)
+        public async Task It_should_replace_meta_url_with_local_path(string tag, string host, string localUrl)
         {
             // Given 
             string content = $"<html><head>{tag}</head><body></body>";
 
             var document = new TestDocument(content);
 
+            var context = new TestExecutionContext();
+            context.Settings[Keys.Host] = host;
+            context.Settings[Keys.LinksUseHttps] = true;
+
             // When
             var assetParser = new KontentImageProcessor().WithLocalPath("/assets/img");
-            var output = await ExecuteAsync(new[] { document }, assetParser);
+            var output = await ExecuteAsync(new[] { document }, context, assetParser);
 
             // Then
             output.Length.Should().Be(1);

--- a/Kontent.Statiq.Tests/response/getitems.json
+++ b/Kontent.Statiq.Tests/response/getitems.json
@@ -240,5 +240,12 @@
         }
       }
     }
+  },
+  "pagination": {
+    "skip": 0,
+    "limit": 10,
+    "count": 10,
+    "total_count": 1,
+    "next_page": "https://deliver.kontent.ai/<project_id>/<resource>?limit=10&skip=10"
   }
 }

--- a/Kontent.Statiq/Html/HtmlHelpers.cs
+++ b/Kontent.Statiq/Html/HtmlHelpers.cs
@@ -1,4 +1,4 @@
-﻿using Kentico.Kontent.Delivery.ContentItems;
+﻿using Kentico.Kontent.Delivery.Abstractions;
 using Kentico.Kontent.ImageTransformation;
 using Statiq.Common;
 using System.Collections.Generic;
@@ -12,11 +12,11 @@ namespace Kontent.Statiq.Html
     public static class HtmlHelpers
     {
         /// <summary>
-        /// Build an image url from an <see cref="Asset"/>.
+        /// Build an image url from an <see cref="IAsset"/>.
         /// </summary>
         /// <param name="asset"></param>
         /// <returns>An <see cref="ImageUrlBuilder"/> for the asset.</returns>
-        public static ImageUrlBuilder ImageUrl(this Asset asset)
+        public static ImageUrlBuilder ImageUrl(this IAsset asset)
         {
             return new ImageUrlBuilder(asset.Url);
         }
@@ -34,7 +34,7 @@ namespace Kontent.Statiq.Html
                 return string.Empty;
             }
 
-            var assets = document.Get<IEnumerable<Asset>>(codename);
+            var assets = document.Get<IEnumerable<IAsset>>(codename);
             return assets?.FirstOrDefault()?.Url ?? string.Empty;
         }
     }

--- a/Kontent.Statiq/Kontent.Statiq.csproj
+++ b/Kontent.Statiq/Kontent.Statiq.csproj
@@ -23,8 +23,8 @@
   <ItemGroup>
     <PackageReference Include="Kentico.Kontent.Delivery" Version="14.0.0-rc1" />
     <PackageReference Include="Kentico.Kontent.ImageTransformation" Version="14.0.0-rc1" />
-    <PackageReference Include="Statiq.Common" Version="1.0.0-beta.17" />
-    <PackageReference Include="Statiq.Core" Version="1.0.0-beta.17" />
+    <PackageReference Include="Statiq.Common" Version="1.0.0-beta.20" />
+    <PackageReference Include="Statiq.Core" Version="1.0.0-beta.20" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Kontent.Statiq/Kontent.Statiq.csproj
+++ b/Kontent.Statiq/Kontent.Statiq.csproj
@@ -21,11 +21,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Kentico.Kontent.Delivery" Version="14.0.0-beta7" />
-    <PackageReference Include="Kentico.Kontent.ImageTransformation" Version="14.0.0-beta7" />
+    <PackageReference Include="Kentico.Kontent.Delivery" Version="14.0.0-rc1" />
+    <PackageReference Include="Kentico.Kontent.ImageTransformation" Version="14.0.0-rc1" />
     <PackageReference Include="Statiq.Common" Version="1.0.0-beta.17" />
     <PackageReference Include="Statiq.Core" Version="1.0.0-beta.17" />
-    <PackageReference Include="Statiq.Html" Version="1.0.0-beta.17" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Kontent.Statiq/KontentImageProcessor.cs
+++ b/Kontent.Statiq/KontentImageProcessor.cs
@@ -16,6 +16,9 @@ namespace Kontent.Statiq
     /// <summary>
     /// Parses HTML to find images used in the document. The urls are replaced with local urls and the
     /// asset download urls are added to the output document.
+    /// <para>
+    /// Note that social sharing images require full url so please configure the <c>Host</c> and <c>LinksUseHttps</c> settings.
+    /// </para>
     /// </summary>
     public class KontentImageProcessor : Module
     {
@@ -75,7 +78,7 @@ namespace Kontent.Statiq
                 context.LogDebug("Replacing image {0} => {1}", image.Source, localPath);
 
                 // update the content
-                image.Source = localPath.IsRelative ? "/" + localPath : localPath.ToString();
+                image.Source = context.GetLink(localPath);
 
                 // add the url for downloading
                 downloadUrls.Add(new KontentImageDownload(imageSource, localPath));
@@ -89,7 +92,7 @@ namespace Kontent.Statiq
 
                 context.LogDebug("Replacing metadata image {0} => {1}", imageSource, localPath);
 
-                meta.SetAttribute(AttributeNames.Content, localPath.IsRelative ? "/" + localPath : localPath.ToString());
+                meta.SetAttribute(AttributeNames.Content, context.GetLink(localPath, true));
 
                 // add the url for downloading
                 downloadUrls.Add(new KontentImageDownload(imageSource, localPath));


### PR DESCRIPTION
Update to Kontent Delivery SDK RC1 and Statiq Beta 20

* Kontent now requires a pagination object in the json response
* There's version conflict an AngleSharp between the Kontent Delivery SDK and Statiq.Html. No longer using Statiq.Html because of that.

This relates to #3 