### PR TITLE
Ensure assets are downloaded just once

### DIFF
--- a/Kontent.Statiq.Tests/LinqExtensionsTests.cs
+++ b/Kontent.Statiq.Tests/LinqExtensionsTests.cs
@@ -1,0 +1,29 @@
+﻿using Statiq.Common;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using Xunit;
+
+namespace Kontent.Statiq.Tests
+{
+    public class LinqExtensionsTests
+    {
+        [Fact]
+        public void DistinctRemovesDuplicateEntriesFromASequence()
+        {
+            // Arrange
+            var assets = new List<KontentImageDownload> {
+                new KontentImageDownload("a", new NormalizedPath("/a/")),
+                new KontentImageDownload("a", new NormalizedPath("/a/")),
+                new KontentImageDownload("b", new NormalizedPath("/b/"))
+            };
+
+            // Act
+            var assetUrls = assets.DistinctBy(a => a.LocalPath);
+
+            // Assert
+            Assert.Equal(2, assetUrls.Count());
+            Assert.NotEqual(assetUrls.FirstOrDefault().LocalPath, assetUrls.LastOrDefault().LocalPath);
+        }
+    }
+}

--- a/Kontent.Statiq/KontentDownloadImages.cs
+++ b/Kontent.Statiq/KontentDownloadImages.cs
@@ -20,7 +20,7 @@ namespace Kontent.Statiq
                 .SelectMany(doc => doc.GetKontentImageDownloads())
                 .ToArray();
 
-            var assetUrls = assets.Select(a => a.OriginalUrl).ToArray(); // TODO: distinct by local path
+            var assetUrls = assets.DistinctBy(a => a.LocalPath).Select(a => a.OriginalUrl).ToArray();
 
             WithUris(assetUrls.ToArray());
 

--- a/Kontent.Statiq/LinqExtensions.cs
+++ b/Kontent.Statiq/LinqExtensions.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Kontent.Statiq
+{
+    /// <summary>
+    /// Extension methods enriching the LINQ syntax.
+    /// </summary>
+    public static class LinqExtensions
+    {
+        /// <summary>
+        /// Returns distinct elements from a sequence by using an equality comparer based on specified properties.
+        /// </summary>
+        /// <typeparam name="TSource">The type of the elements of source.</typeparam>
+        /// <typeparam name="TKey">The type of the selector key.</typeparam>
+        /// <param name="source">The sequence to remove duplicate elements from.</param>
+        /// <param name="keySelector">Selector allowing to specify one or more properties to base the filtering on.</param>
+        /// <returns><see cref="IEnumerable{T}"/> that contains distinct elements from the source sequence.</returns>
+        public static IEnumerable<TSource> DistinctBy<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector)
+        {
+            HashSet<TKey> seenKeys = new HashSet<TKey>();
+            foreach (TSource element in source)
+            {
+                if (seenKeys.Add(keySelector(element)))
+                {
+                    yield return element;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Avoids the "Multiple documents… output to" error.

### Motivation
OCD (and also performance)

### Checklist

- [x] Code follows coding conventions held in this repo
- [x] Automated tests have been added
- [x] Tests are passing
- [x] ~~Docs have been updated (if applicable)~~ N/A
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

- create two or more pipelines with `KontentImageProcessor` whose output will contain assets (<img src>) with the same URLs
- create another pipeline based on the `KontentDownloadImages`
- run `dotnet run -- preview` and make sure that:
  - there are no errors in the log such as `Multiple documents output to img/1.jpg (this probably wasn't intended)`
  - all assets are downloaded correctly