### PR TITLE
Improved Kontent API error handling

### DIFF
--- a/Kontent.Statiq.Tests/Tools/KontentSetupHelpers.cs
+++ b/Kontent.Statiq.Tests/Tools/KontentSetupHelpers.cs
@@ -28,6 +28,7 @@ namespace Kontent.Statiq.Tests.Tools
                 moreData = false; // return a single batch
                 var data = A.Fake<IDeliveryItemsFeedResponse<TContent>>();
                 A.CallTo(() => data.Items).Returns(content);
+                A.CallTo(() => data.ApiResponse.IsSuccess).Returns(true);
                 return Task.FromResult(data);
             });
             A.CallTo(() => client.GetItemsFeed<TContent>(A<IEnumerable<IQueryParameter>>._))

--- a/Kontent.Statiq.Tests/Tools/KontentSetupHelpers.cs
+++ b/Kontent.Statiq.Tests/Tools/KontentSetupHelpers.cs
@@ -11,13 +11,25 @@ namespace Kontent.Statiq.Tests.Tools
         {
             var response = A.Fake<IDeliveryItemListingResponse<TContent>>();
             A.CallTo(() => response.ApiResponse.IsSuccess).Returns(true);
-            A.CallTo(() => response.Items).Returns( content );
+            A.CallTo(() => response.Items).Returns(content);
             A.CallTo(() => client.GetItemsAsync<TContent>(A<IEnumerable<IQueryParameter>>._))
                 .Returns(response);
 
             return client;
         }
-        
+
+        public static IDeliveryClient WithFakeContentError<TContent>(this IDeliveryClient client)
+        {
+            var response = A.Fake<IDeliveryItemListingResponse<TContent>>();
+            A.CallTo(() => response.ApiResponse.IsSuccess).Returns(false);
+            A.CallTo(() => response.ApiResponse.Error.Message).Returns("Oops");
+            A.CallTo(() => response.Items).Returns(null!);
+            A.CallTo(() => client.GetItemsAsync<TContent>(A<IEnumerable<IQueryParameter>>._))
+                .Returns(response);
+
+            return client;
+        }
+
         public static IDeliveryClient WithFakeContentFeed<TContent>(this IDeliveryClient client, params TContent[] content)
         {
             var response = A.Fake<IDeliveryItemsFeed<TContent>>();
@@ -29,6 +41,26 @@ namespace Kontent.Statiq.Tests.Tools
                 var data = A.Fake<IDeliveryItemsFeedResponse<TContent>>();
                 A.CallTo(() => data.Items).Returns(content);
                 A.CallTo(() => data.ApiResponse.IsSuccess).Returns(true);
+                return Task.FromResult(data);
+            });
+            A.CallTo(() => client.GetItemsFeed<TContent>(A<IEnumerable<IQueryParameter>>._))
+                .Returns(response);
+
+            return client;
+        }
+
+        public static IDeliveryClient WithFakeContentFeedError<TContent>(this IDeliveryClient client)
+        {
+            var response = A.Fake<IDeliveryItemsFeed<TContent>>();
+            var moreData = true;
+            A.CallTo(() => response.HasMoreResults).ReturnsLazily(_ => moreData);
+            A.CallTo(() => response.FetchNextBatchAsync(A<string>.Ignored)).ReturnsLazily(_ =>
+            {
+                moreData = false; // return a single batch
+                var data = A.Fake<IDeliveryItemsFeedResponse<TContent>>();
+                A.CallTo(() => data.Items).Returns(null!);
+                A.CallTo(() => data.ApiResponse.IsSuccess).Returns(false);
+                A.CallTo(() => data.ApiResponse.Error.Message).Returns("Oops");
                 return Task.FromResult(data);
             });
             A.CallTo(() => client.GetItemsFeed<TContent>(A<IEnumerable<IQueryParameter>>._))

--- a/Kontent.Statiq.Tests/Tools/KontentSetupHelpers.cs
+++ b/Kontent.Statiq.Tests/Tools/KontentSetupHelpers.cs
@@ -10,6 +10,7 @@ namespace Kontent.Statiq.Tests.Tools
         public static IDeliveryClient WithFakeContent<TContent>(this IDeliveryClient client, params TContent[] content)
         {
             var response = A.Fake<IDeliveryItemListingResponse<TContent>>();
+            A.CallTo(() => response.ApiResponse.IsSuccess).Returns(true);
             A.CallTo(() => response.Items).Returns( content );
             A.CallTo(() => client.GetItemsAsync<TContent>(A<IEnumerable<IQueryParameter>>._))
                 .Returns(response);

--- a/Kontent.Statiq.Tests/Tools/LoggerTestExtensions.cs
+++ b/Kontent.Statiq.Tests/Tools/LoggerTestExtensions.cs
@@ -26,8 +26,8 @@ public static class LoggerTestExtensions
     private static (bool found, LogLevel? level, string? message) VerifyLog(this ILogger logger, string message)
     {
         var call = Fake.GetCalls(logger)
-            .FirstOrDefault(call => call.Arguments[2].ToString().Contains(message, StringComparison.OrdinalIgnoreCase));
+            .FirstOrDefault(call => call.Method.Name == "Log" && call.Arguments.Count > 2 && ( call.Arguments[2]?.ToString()?.Contains(message, StringComparison.OrdinalIgnoreCase) ?? false ));
 
-        return (call != null, (LogLevel?)call?.Arguments[0], call?.Arguments[2].ToString());
+        return (call != null, (LogLevel?)call?.Arguments[0], call?.Arguments[2]?.ToString() ?? "");
     }
 }

--- a/Kontent.Statiq.Tests/Tools/LoggerTestExtensions.cs
+++ b/Kontent.Statiq.Tests/Tools/LoggerTestExtensions.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Linq;
+using FakeItEasy;
+using Microsoft.Extensions.Logging;
+using Xunit.Sdk;
+
+namespace Kontent.Statiq.Tests.Tools;
+
+public static class LoggerTestExtensions
+{
+    public static void VerifyLogged(this ILogger logger, LogLevel level, string logMessage)
+    {
+        var (found, actualLevel, actualMessage) = logger.VerifyLog(logMessage);
+        if (!found)
+        {
+            throw new XunitException($"No log message found containing '{logMessage}' at any loglevel");
+        }
+
+        if (actualLevel != level)
+        {
+            throw new AssertActualExpectedException($"[{level}] {logMessage}", $"[{actualLevel}] {actualMessage}",
+                $"Unexpected log level for log message");
+        }
+    }
+        
+    private static (bool found, LogLevel? level, string? message) VerifyLog(this ILogger logger, string message)
+    {
+        var call = Fake.GetCalls(logger)
+            .FirstOrDefault(call => call.Arguments[2].ToString().Contains(message, StringComparison.OrdinalIgnoreCase));
+
+        return (call != null, (LogLevel?)call?.Arguments[0], call?.Arguments[2].ToString());
+    }
+}

--- a/Kontent.Statiq.Tests/When_using_the_items_feed.cs
+++ b/Kontent.Statiq.Tests/When_using_the_items_feed.cs
@@ -7,7 +7,11 @@ using Statiq.Common;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Xunit;
+using System.Linq;
+using Shouldly;
+using Xunit.Sdk;
 
 namespace Kontent.Statiq.Tests
 {
@@ -42,6 +46,23 @@ namespace Kontent.Statiq.Tests
             // Assert
             docs.Should().HaveCount(1);
             A.CallTo(() => deliveryClient.GetItemsFeed<Article>(A<IEnumerable<IQueryParameter>>._)).MustHaveHappenedOnceExactly();
+        }
+
+        [Fact]
+        public async Task It_should_handle_API_errors()
+        {
+            // Arrange
+            var deliveryClient = A.Fake<IDeliveryClient>()
+                .WithFakeContentFeedError<Article>();
+
+            var sut = new Kontent<Article>(deliveryClient)
+                .WithItemsFeed();
+
+            // Act
+            Func<Task> act = async () => await sut.ExecuteAsync(A.Fake<IExecutionContext>());
+
+            // Assert
+            await act.ShouldThrowAsync<InvalidOperationException>();
         }
     }
 }

--- a/Kontent.Statiq/Kontent.cs
+++ b/Kontent.Statiq/Kontent.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Module = Statiq.Common.Module;
 
 namespace Kontent.Statiq
@@ -67,8 +68,17 @@ namespace Kontent.Statiq
             else
             {
                 var items = await _client.GetItemsAsync<TContentModel>(QueryParameters);
+                if (!items.ApiResponse.IsSuccess)
+                {
+                    throw new InvalidOperationException($"Failed to load data from Kontent for content type {typeof(TContentModel).Name} : {items.ApiResponse.Error.Message}");
+                }
 
-                return items.Items.Select(item => KontentDocumentHelpers.CreateDocument(context, item, GetContent)).ToArray();
+                if (items.Items == null || items.Items.Count == 0)
+                {
+                    context.Logger.LogWarning($"Query for {typeof(TContentModel).Name} returned no results.");
+                }
+
+                return items.Items?.Select(item => KontentDocumentHelpers.CreateDocument(context, item, GetContent)).ToArray() ?? Array.Empty<IDocument>();
             }
         }
     }

--- a/Kontent.Statiq/Kontent.cs
+++ b/Kontent.Statiq/Kontent.cs
@@ -57,7 +57,11 @@ namespace Kontent.Statiq
                 while (feed.HasMoreResults)
                 {
                     var nextBatch = await feed.FetchNextBatchAsync();
-                    
+                    if (!nextBatch.ApiResponse.IsSuccess)
+                    {
+                        throw new InvalidOperationException($"Failed to load data from Kontent item feed for content type {typeof(TContentModel).Name} : {nextBatch.ApiResponse.Error.Message}");
+                    }
+
                     var outputDocuments = nextBatch.Items.Select(item => KontentDocumentHelpers.CreateDocument(context, item, GetContent)).ToArray();
                     
                     documents.AddRange(outputDocuments);


### PR DESCRIPTION
### Motivation

Kontent API errors were not handled, causing nullref exceptions that were hard to trace back.

### Checklist

- [X] Code follows coding conventions held in this repo
- [X] Automated tests have been added
- [X] Tests are passing
- [X] Docs have been updated (if applicable)
- [X] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

Setup an invalid config for the Kontent client. For example try loading preview content without setting the preview API key.