### PR TITLE
Update Kontent.Ai.Delivery to 18.3.0 and refresh dependencies

### DIFF
--- a/Kontent.Statiq.Tests/Kontent.Statiq.Tests.csproj
+++ b/Kontent.Statiq.Tests/Kontent.Statiq.Tests.csproj
@@ -7,20 +7,20 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FakeItEasy" Version="8.1.0" />
+    <PackageReference Include="FakeItEasy" Version="9.0.1" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageReference Include="RichardSzalay.MockHttp" Version="7.1.0" />
     <PackageReference Include="Statiq.Core" Version="1.0.0-*" />
     <PackageReference Include="Statiq.Razor" Version="1.0.0-*" />
     <PackageReference Include="Statiq.Testing" Version="1.0.0-*" />
-    <PackageReference Include="xunit" Version="2.7.0" />
-    <PackageReference Include="xunit.assert" Version="2.7.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.assert" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.1">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Kontent.Statiq/Kontent.Statiq.csproj
+++ b/Kontent.Statiq/Kontent.Statiq.csproj
@@ -29,7 +29,7 @@
     </AssemblyAttribute>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Kontent.Ai.Delivery" Version="18.0.0" />
+    <PackageReference Include="Kontent.Ai.Delivery" Version="18.3.0" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="9.20.0.85982">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
### Motivation

Pick up the latest 18.x of the Kontent Delivery SDK before cutting a release. There are no API changes in this bump, so nothing in Kontent.Statiq had to change.

The main gain is dependency hygiene: the transitive `Microsoft.Extensions.*` packages move from 6.0.x to 8.0.x, matching the framework we target, and Scrutor goes from 4.2.0 to 5.0.2.

### Why not 19.x

Delivery 19.0 is a ground-up redesign of the SDK. The query parameter classes (`IQueryParameter`, `EqualsFilter`, `LimitParameter`, ...) are replaced by a fluent builder, `GetItemsAsync` becomes `GetItems<T>()....ExecuteAsync()` returning a result type, and system attributes move off the content model onto a wrapper.

Kontent.Statiq's own public API is built on those types:

```csharp
public static Kontent<T> WithQuery<T>(this Kontent<T> module, params IQueryParameter[] queryParameters)
public static Kontent<T> OrderBy<T>(this Kontent<T> module, string field, SortOrder sortOrder)
```

So moving to 19.x is a breaking change for our consumers and needs its own design pass, README rewrite and major version. Tracked separately.

### Checklist

- [X] Code follows coding conventions held in this repo
- [ ] Automated tests have been added - not applicable, no behaviour change
- [X] Tests are passing
- [ ] Docs have been updated (if applicable) - not applicable
- [X] Temporary settings have been reverted to defaults

### How to test

`dotnet build` and `dotnet test`. All 41 tests pass and the build stays warning free.