### PR TITLE
Trusted publishing, and harden the workflows against the security guidelines

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+
+updates:
+  # Actions in the workflows are pinned to commit SHAs, which freezes them until
+  # something moves the pins. This is what moves them - don't disable it.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "ci"
+
+  - package-ecosystem: nuget
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      test-dependencies:
+        patterns:
+        - xunit*
+        - FakeItEasy
+        - FluentAssertions
+        - Microsoft.NET.Test.Sdk
+        - RichardSzalay.MockHttp
+        - coverlet.*
+    ignore:
+      # Version 8 moved to the Xceed Community License, which requires a paid
+      # licence for commercial use.
+      - dependency-name: FluentAssertions
+        versions: [">=8.0.0"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,26 +16,28 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         fetch-depth: 0 # GitVersion needs the full history and all tags
     - name: Install GitVersion
-      uses: gittools/actions/gitversion/setup@v1.2.0
+      uses: gittools/actions/gitversion/setup@dcb17efb49ec7f20efdebce79cc397a3952c63db # v1.2.0
       with:
         versionSpec: '5.x'
     - name: Use GitVersion
       id: gitversion # step id used as reference for output values
-      uses: gittools/actions/gitversion/execute@v1.2.0
+      uses: gittools/actions/gitversion/execute@dcb17efb49ec7f20efdebce79cc397a3952c63db # v1.2.0
     - name: Setup dotnet
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
       with:
         dotnet-version: |
           8.x
     - name: Build with dotnet
-      run: dotnet build --configuration Release -p:Version=${{ steps.gitversion.outputs.nuGetVersionV2 }}
+      env:
+        VERSION: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
+      run: dotnet build --configuration Release -p:Version="$VERSION"
     - name: Test with dotnet
       run: dotnet test --configuration Release --no-build
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: nuget
         path: "**/Kontent.Statiq*.s?nupkg"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,9 @@ jobs:
   publish:
     timeout-minutes: 10
     runs-on: ubuntu-latest
+    permissions:
+      contents: read  # to download the release assets
+      id-token: write # to request the OIDC token for trusted publishing
 
     steps:
     - name: Download release assets
@@ -22,8 +25,15 @@ jobs:
       with:
         dotnet-version: |
           8.x
+    # Trusted publishing: exchange a GitHub OIDC token for a short-lived nuget.org
+    # API key. The key is valid for one hour and can only be used once, so this has
+    # to run right before the push. See the trusted publishing policy on nuget.org,
+    # which is tied to this workflow being called publish.yml - don't rename it.
+    - name: Log in to nuget.org
+      uses: NuGet/login@v1
+      id: nuget-login
+      with:
+        user: marnixvanvalen # nuget.org profile name, not an email address
     - name: Publish package
-      env:
-        NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
       # Pushing the .nupkg also pushes the matching .snupkg symbols package
-      run: dotnet nuget push ./*.nupkg --api-key $NUGET_API_KEY -s https://api.nuget.org/v3/index.json
+      run: dotnet nuget push ./*.nupkg --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,9 +19,10 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GH_REPO: ${{ github.repository }}
-      run: gh release download "${{ github.event.release.tag_name }}" --pattern "*.nupkg" --pattern "*.snupkg"
+        RELEASE_TAG: ${{ github.event.release.tag_name }}
+      run: gh release download "$RELEASE_TAG" --pattern "*.nupkg" --pattern "*.snupkg"
     - name: Setup dotnet
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
       with:
         dotnet-version: |
           8.x
@@ -30,10 +31,13 @@ jobs:
     # to run right before the push. See the trusted publishing policy on nuget.org,
     # which is tied to this workflow being called publish.yml - don't rename it.
     - name: Log in to nuget.org
-      uses: NuGet/login@v1
+      uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
       id: nuget-login
       with:
         user: marnixvanvalen # nuget.org profile name, not an email address
     - name: Publish package
+      env:
+        # Passed as environment data, never as a command line argument
+        NUGET_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
       # Pushing the .nupkg also pushes the matching .snupkg symbols package
-      run: dotnet nuget push ./*.nupkg --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json
+      run: dotnet nuget push ./*.nupkg --api-key "$NUGET_API_KEY" -s https://api.nuget.org/v3/index.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,26 +14,28 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         fetch-depth: 0 # GitVersion needs the full history and all tags
     - name: Install GitVersion
-      uses: gittools/actions/gitversion/setup@v1.2.0
+      uses: gittools/actions/gitversion/setup@dcb17efb49ec7f20efdebce79cc397a3952c63db # v1.2.0
       with:
         versionSpec: '5.x'
     - name: Use GitVersion
       id: gitversion # step id used as reference for output values
-      uses: gittools/actions/gitversion/execute@v1.2.0
+      uses: gittools/actions/gitversion/execute@dcb17efb49ec7f20efdebce79cc397a3952c63db # v1.2.0
     - name: Setup dotnet
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
       with:
         dotnet-version: |
           8.x
     - name: Build with dotnet
-      run: dotnet build --configuration Release -p:Version=${{ steps.gitversion.outputs.nuGetVersionV2 }}
+      env:
+        VERSION: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
+      run: dotnet build --configuration Release -p:Version="$VERSION"
     - name: Test with dotnet
       run: dotnet test --configuration Release --no-build
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: nuget
         path: |
@@ -52,7 +54,7 @@ jobs:
       contents: write # needed to create the release
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: nuget
           path: ./
@@ -64,6 +66,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
+          TAG: ${{ github.ref_name }}
+          VERSION: ${{ needs.build.outputs.nugetversion }}
           PRERELEASE: ${{ needs.build.outputs.prerelease }}
         run: |
           # PRERELEASE is the string "true" or "false", so test it explicitly
@@ -72,9 +76,9 @@ jobs:
           else
             prerelease_flag=""
           fi
-          gh release create "${{ github.ref_name }}" \
+          gh release create "$TAG" \
             --draft \
-            --title "Release ${{ needs.build.outputs.nugetversion }}" \
+            --title "Release $VERSION" \
             $prerelease_flag \
-            ./Kontent.Statiq.${{ needs.build.outputs.nugetversion }}.nupkg \
-            ./Kontent.Statiq.${{ needs.build.outputs.nugetversion }}.snupkg
+            "./Kontent.Statiq.$VERSION.nupkg" \
+            "./Kontent.Statiq.$VERSION.snupkg"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,11 @@ provides [Statiq](https://statiq.dev) modules for pulling content and assets fro
 
 Repo: https://github.com/alanta/Kontent.Statiq · License: MIT · Package: `Kontent.Statiq`
 
+> **Read [SECURITY_GUIDELINES.md](SECURITY_GUIDELINES.md) before changing anything under
+> `.github/workflows/` or touching dependencies.** Those rules are binding, they include a
+> review checklist to run your diff against, and a deviation has to be stated in the PR
+> description rather than left for the reviewer to spot.
+
 ## Layout
 
 | Path | What it is |

--- a/SECURITY_GUIDELINES.md
+++ b/SECURITY_GUIDELINES.md
@@ -1,0 +1,202 @@
+# Security guidelines
+
+Rules for writing and reviewing code in this repository.
+
+Both humans and coding agents should treat these as binding. If you are an agent making
+changes here, check your diff against the [review checklist](#review-checklist) before
+handing work back.
+
+Two framing notes:
+
+- **These are classes, not incidents.** A rule exists because a whole category of mistake is
+  cheap to prevent and expensive to find later — not because one line once got flagged.
+- **Deviations are allowed, silently deviating is not.** If a rule genuinely does not fit,
+  say so in the PR description and explain why. An unexplained exception reads as an
+  oversight to the next reviewer.
+
+---
+
+## 1. GitHub Actions workflows
+
+CI has credentials — OIDC federation to nuget.org (trusted publishing), `packages: write` to
+GHCR. A workflow compromise is a supply-chain compromise, so workflows get the same scrutiny
+as production code.
+
+### 1.1 Never interpolate context values into a `run:` body
+
+`${{ ... }}` is substituted as **raw text before the shell ever starts**. A value containing
+shell metacharacters becomes executable code, not a string — quoting does not save you,
+because the quotes themselves are part of the text being replaced.
+
+Pass through `env:` and dereference as a shell variable. The value then arrives as
+environment data that the shell never parses as syntax.
+
+```yaml
+# WRONG - inputs.location is pasted into the script text
+- run: bash scripts/deploy.sh "${{ inputs.location }}"
+
+# RIGHT - the value arrives as data
+- env:
+    LOCATION: ${{ inputs.location }}
+  run: bash scripts/deploy.sh "$LOCATION"
+```
+
+This applies to **every** context — `inputs`, `vars`, `env`, `steps.*.outputs`, `needs.*`,
+and all of `github.*`. Do not try to classify a context as trusted; the rule is uniform
+because the exceptions are hard to reason about and change over time.
+
+Highest-risk fields, where the content is attacker-controlled by design:
+`github.event.issue.title`, `.body`, `.head_ref`, `.pull_request.*`, commit messages, and
+author names.
+
+Interpolation in `with:`, `if:`, and `env:` blocks is fine — those are structured YAML
+inputs, not shell text. Only `run:` bodies are affected.
+
+### 1.2 Pin third-party actions to a full commit SHA
+
+A tag is a mutable pointer. Whoever controls the action repository can repoint `v4` at new
+code, and it runs with your workflow's token on your next build.
+
+```yaml
+# WRONG - mutable
+uses: dorny/paths-filter@v4
+
+# RIGHT - immutable, with the human-readable version retained
+uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4
+```
+
+- Pin **all** actions, including `actions/*`. GitHub's own namespace is lower risk, not zero
+  risk, and a uniform rule is easier to enforce than a judgement call per action.
+- Always keep the `# vN` trailer. Without it nobody can tell what a bare hash is.
+- Use the full 40-character commit SHA. Short SHAs and tag-object SHAs are not acceptable.
+- Get the SHA from the action's own repository, not from a search result:
+  ```bash
+  gh api repos/OWNER/REPO/git/ref/tags/vN --jq '.object.sha'
+  ```
+  If that returns an annotated tag object (`.object.type == "tag"`), dereference it with
+  `gh api repos/OWNER/REPO/git/tags/SHA --jq '.object.sha'` to get the commit.
+
+**Pinning without automation is a downgrade.** A pin freezes the action forever, including
+past security fixes. `.github/dependabot.yml` carries a `github-actions` entry that keeps
+pins moving; if you add a workflow, it is already covered — do not disable it.
+
+When bumping a major version, confirm the inputs you use still exist at the new major before
+merging. Reading `action.yml` at the pinned SHA is enough:
+
+```bash
+gh api repos/OWNER/REPO/contents/action.yml?ref=SHA --jq '.content' | base64 -d
+```
+
+### 1.3 Least-privilege tokens
+
+- Declare `permissions:` explicitly in every workflow. The default is too broad.
+- Start from `contents: read` and add only what a job proves it needs.
+- Prefer job-level `permissions:` over workflow-level when only one job needs the extra
+  scope — a release workflow should not grant `contents: write` to its build job.
+- Use OIDC (`id-token: write` plus a trusted-publishing exchange, e.g. `NuGet/login`) for
+  publishing credentials. Do not add long-lived API keys or tokens as repository secrets.
+
+### 1.4 Untrusted triggers
+
+- `pull_request` from a fork gets a read-only token and no secrets. Keep it that way.
+- Do not add `pull_request_target` or `workflow_run` to run untrusted code. They execute in
+  a trusted context with secrets available, and combined with a checkout of the PR head they
+  are a direct path to credential theft. If you believe you need one, raise it for review
+  first.
+- Never `echo` a secret, and never pass one as a command-line argument — arguments are
+  visible in process listings. Use `env:` or stdin.
+
+---
+
+## 2. Dependencies
+
+### 2.1 Lock files are mandatory
+
+Every .NET project writes a `packages.lock.json` (`RestorePackagesWithLockFile` in
+`Directory.Build.props`), which pins the **full transitive closure** to exact versions and
+content hashes. CI restores with `--locked-mode`, so a dependency that resolves differently
+than what was committed fails the build instead of silently shipping.
+
+This is what defends against a transitive dependency changing under you between the commit
+that was reviewed and the build that ships.
+
+Consequence for anyone changing packages: **a version change and its regenerated lock files
+belong in the same commit.**
+
+```bash
+dotnet restore EasyAuthDevProxy.slnx --force-evaluate   # after any package change
+```
+
+Skipping this fails CI with `NU1004`. Do not "fix" that by dropping `--locked-mode` or
+disabling the property — the failure is the control working.
+
+### 2.2 One version per package
+
+.NET package versions live only in `Directory.Packages.props` (Central Package Management).
+
+- Do not put a `Version` attribute on a `PackageReference` in a project file.
+- Add the `PackageVersion` entry centrally first, then reference the package.
+- Avoid `VersionOverride`. It reintroduces exactly the per-project drift that CPM exists to
+  eliminate. If one project truly cannot move, use it — and write down why and what would
+  let it be removed.
+
+Version drift is a security problem, not just a tidiness one: it means a patched version in
+one project silently coexists with a vulnerable one in another, and neither an audit nor a
+scanner report tells you which is deployed.
+
+Aspire packages are the documented exception — they come implicitly from
+`Aspire.AppHost.Sdk` and are versioned by the `Sdk` attribute in `AppHost.csproj`.
+
+### 2.3 Responding to a vulnerability report
+
+1. Prefer the smallest upgrade that clears the advisory. Take the patched version, not the
+   newest available.
+2. Bump **indirect** dependencies directly when the advisory names them — you do not have to
+   wait for the intermediate package to update. Add a `PackageVersion` entry for the
+   transitive package in `Directory.Packages.props` even though nothing references it
+   directly yet; NuGet will pick it up once something in the graph needs it.
+3. Rebuild and run the full test suite. A dependency bump is a code change.
+4. Do not suppress or ignore a finding to make a scan pass. If a finding is genuinely not
+   applicable, record the reasoning where the next person will find it.
+
+Judge exploitability honestly, in both directions. A DoS in a parser this codebase never
+reaches is lower priority than its CVSS implies — but "we probably don't call that path" is
+an argument for scheduling, never for silence.
+
+### 2.4 Adding a dependency
+
+Before introducing one, consider whether the standard library covers it. Each new dependency
+is permanent attack surface and someone else's release process. When you do add one:
+
+- Check it is actively maintained and not deprecated.
+- Add it centrally (see 2.2) and regenerate lock files (see 2.1).
+- Prefer packages already in the closure over a new one doing a similar job.
+
+NuGet sources are locked down in `nuget.config` — `<clear/>` plus `packageSourceMapping`, so
+every package must come from nuget.org and nothing can be shadowed by a rogue feed. Do not
+add package sources without review.
+
+---
+
+## 3. Review checklist
+
+Before opening a PR, or before an agent reports work complete:
+
+**If workflows changed**
+- [ ] No `${{ }}` anywhere inside a `run:` body — context values go through `env:`
+- [ ] Every action pinned to a 40-char commit SHA with a `# vN` trailer
+- [ ] `permissions:` declared and no broader than the job needs
+- [ ] No new secret echoed, logged, or passed as a command-line argument
+
+**If dependencies changed**
+- [ ] Versions changed only in `Directory.Packages.props` (no `Version` on a `PackageReference`)
+- [ ] Lock files regenerated and committed in the same commit
+- [ ] `dotnet restore --locked-mode` succeeds from clean
+- [ ] Build and full test suite pass
+
+**Always**
+- [ ] No credentials, tokens, connection strings, or keys in source, config, or fixtures
+- [ ] Nothing security-relevant weakened without saying so explicitly in the PR description
+
+A verification you did not actually run does not count. Run the command, read the output,
+and report what it said — including when it failed.


### PR DESCRIPTION
### Motivation

nuget.org is moving away from long-lived API keys in favour of [trusted publishing](https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing). The workflow now exchanges a GitHub OIDC token for a short-lived nuget.org API key instead of using the `NUGET_API_KEY` secret.

The `NUGET_API_KEY` secret dates from 2022 and has not been used since, so this also removes a stale credential rather than renewing it.

### What changed

* `publish.yml` requests an OIDC token (`id-token: write`) and calls `NuGet/login@v1` to get a temporary key.
* The push uses that key instead of the secret.
* Job level permissions are declared explicitly: `contents: read` to download the release assets, `id-token: write` for the token exchange.

The issued key is valid for one hour and can only be used once, so the login step sits immediately before the push.

### Notes

* The trusted publishing policy on nuget.org is bound to the workflow **file name**, so `publish.yml` must not be renamed. There is a comment in the file saying so.
* The nuget.org user is set to the profile name `marnixvanvalen`. It is an identifier rather than a credential and is public on the package page, so it is inline rather than a secret. Happy to move it to `secrets.NUGET_USER` if preferred.
* No GitHub environment is used, matching how the policy is configured.
* Once a release has published successfully this way, the `NUGET_API_KEY` secret can be deleted from the repository settings.

### How to test

This workflow only runs on `release: published`, so it cannot be exercised by CI. It will run for real when the `v2.0-beta16` draft release is published. The draft release itself is produced by `release.yml` and needs no nuget.org credentials, so the risky part is isolated to this one step.

Validated with `actionlint` and a YAML parse.