### PR TITLE
Fix the version calculated for releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,17 @@ updates:
       interval: weekly
     commit-message:
       prefix: "ci"
+    ignore:
+      # v1.2.0 is the last release of these actions that installs GitVersion 5.
+      # v2 and up install GitVersion 6, which renames the ContinuousDelivery mode
+      # we use to ManualDeployment and removes the NuGetVersionV2 output that all
+      # three workflows read. Taking such a bump would silently change the version
+      # of every published package. Only move these as part of a deliberate
+      # GitVersion 6 migration.
+      - dependency-name: gittools/actions/gitversion/setup
+        versions: [">=2.0.0"]
+      - dependency-name: gittools/actions/gitversion/execute
+        versions: [">=2.0.0"]
 
   - package-ecosystem: nuget
     directory: /

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,12 @@ jobs:
     - name: Use GitVersion
       id: gitversion # step id used as reference for output values
       uses: gittools/actions/gitversion/execute@dcb17efb49ec7f20efdebce79cc397a3952c63db # v1.2.0
+      env:
+        # On a tag push GITHUB_REF is refs/tags/<tag>, and GitVersion takes its branch
+        # name from the build environment. It would treat "tags/v2.0-beta16" as a branch
+        # and produce a version like 2.0.0-tags-v2-0-beta1-0001. Releases are always
+        # tagged on main, so tell GitVersion that is the branch it is looking at.
+        GITHUB_REF: refs/heads/main
     - name: Setup dotnet
       uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
       with:

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,6 +1,9 @@
 mode: ContinuousDelivery
 branches:
   master: {
-    regex: ^main
+    regex: ^main,
+    # Releases from main are prereleases while Statiq itself is still in beta.
+    # This produces 2.0.0-beta.16 / NuGet 2.0.0-beta0016, continuing the sequence
+    # of the 2.0.0-beta0015 package that is on nuget.org.
+    tag: beta
   }
-


### PR DESCRIPTION
Tagging `v2.0-beta16` produced a package called `Kontent.Statiq.2.0.0-tags-v2-0-beta1-0001.nupkg`. The workflow ran green end to end - the draft release gate is what stopped it reaching nuget.org. The tag and the draft release have been deleted.

There were two independent problems.

### 1. GitVersion read the tag ref as a branch name

On a tag push `GITHUB_REF` is `refs/tags/<tag>`, and GitVersion takes its branch from the build environment:

```
Branch from build environment: refs/tags/v2.0-beta16
Creating local branch tags/v2.0-beta16 pointing at bbdcf97
HEAD points at branch 'refs/heads/tags/v2.0-beta16'
```

It then sanitized that "branch name" into the version. Releases are always tagged on main, so the GitVersion step now sets `GITHUB_REF: refs/heads/main`.

### 2. Main had no prerelease label

With `mode: ContinuousDelivery` and no label on the main branch config, main resolves to a **stable** `2.0.0` - which is also why NU5104 (stable package, prerelease Statiq dependency) started showing up on main builds. Adding `tag: beta` yields `2.0.0-beta.16`, NuGet `2.0.0-beta0016`, continuing the sequence of the `2.0.0-beta0015` package already on nuget.org. It also clears NU5104, since the version is a prerelease again.

### Verification

GitVersion 5.12 run locally against a fresh clone left exactly the way `actions/checkout` leaves it on a tag push - detached at the tag:

```
detached HEAD at bbdcf97
  GITHUB_REF=refs/tags/v2.0-beta16   ->  2.0.0-tags-v2-0-beta1-0001
  GITHUB_REF=refs/heads/main         ->  2.0.0-beta0016 | SemVer 2.0.0-beta.16 | prerelease: True
```

The same harness confirmed the result is stable whether or not a tag is on HEAD and regardless of tag format (`v2.0-beta16`, `v2.0.0-beta16`, `v2.0.0-beta.16` all give `2.0.0-beta0016` via the main ref).

### On Mainline mode

Worth recording, since it came up. `mode: Mainline` **is** immune to problem 1 - it returns the same version via the tag ref and the branch ref. But it produces `2.0.0-beta` with no number, which cannot be published twice, and with a plain stable tag it reintroduces the tag-ref bug (`v2.0.1` gives `2.0.2-tags-v2-0-1-0001`). The missing piece was the branch label, not the mode.

### Worth knowing

**The tag has never determined the version**, before or after this change. The version comes from the commit distance on main; the tag only decides *when* a release is built. Checked out at the historical `v2.0-beta15` tag, GitVersion does not reproduce `2.0.0-beta0015` either, so the previously published packages did not come from this path as configured.

Consequence: the next release is `2.0.0-beta0016` because there are 16 commits since the version source, not because of what the tag is called. Tag naming stays a human convention.

### How to test

Merge, then push a `v*` tag and check the draft release before publishing it.