### PR TITLE
Calculate the release version without the gittools action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,24 +17,40 @@ jobs:
     - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         fetch-depth: 0 # GitVersion needs the full history and all tags
-    - name: Install GitVersion
-      uses: gittools/actions/gitversion/setup@dcb17efb49ec7f20efdebce79cc397a3952c63db # v1.2.0
-      with:
-        versionSpec: '5.x'
-    - name: Use GitVersion
-      id: gitversion # step id used as reference for output values
-      uses: gittools/actions/gitversion/execute@dcb17efb49ec7f20efdebce79cc397a3952c63db # v1.2.0
-      env:
-        # On a tag push GITHUB_REF is refs/tags/<tag>, and GitVersion takes its branch
-        # name from the build environment. It would treat "tags/v2.0-beta16" as a branch
-        # and produce a version like 2.0.0-tags-v2-0-beta1-0001. Releases are always
-        # tagged on main, so tell GitVersion that is the branch it is looking at.
-        GITHUB_REF: refs/heads/main
+    # actions/checkout leaves us detached at the tag, and GitVersion needs to see a
+    # branch to work out the version. Releases are always cut from main, so put main
+    # on the commit that was tagged.
+    - name: Point main at the tagged commit
+      run: git checkout -B main "$GITHUB_SHA"
     - name: Setup dotnet
       uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
       with:
         dotnet-version: |
           8.x
+    # The gittools action is not used here. It hands GitVersion the branch from the
+    # build environment, which on a tag push is refs/tags/<tag>, and GitVersion then
+    # treats that as a branch name and produces versions like
+    # 2.0.0-tags-v2-0-beta1-0001. Setting GITHUB_REF on the step does not help, the
+    # action overrides it. Running the CLI with the build server integration disabled
+    # makes GitVersion use the checked out branch instead.
+    - name: Install GitVersion
+      run: |
+        dotnet tool install --global GitVersion.Tool --version 5.12.0
+        echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
+    - name: Use GitVersion
+      id: gitversion
+      run: |
+        version=$(env -u GITHUB_ACTIONS dotnet-gitversion /showvariable NuGetVersionV2)
+        prerelease_tag=$(env -u GITHUB_ACTIONS dotnet-gitversion /showvariable PreReleaseTag)
+        echo "Calculated version: $version"
+        if [ -z "$version" ]; then echo "GitVersion produced no version" >&2; exit 1; fi
+        case "$version" in
+          *tags-*|*no-branch*) echo "Refusing to release with version '$version'" >&2; exit 1 ;;
+        esac
+        {
+          echo "nuGetVersionV2=$version"
+          if [ -n "$prerelease_tag" ]; then echo "prerelease=true"; else echo "prerelease=false"; fi
+        } >> "$GITHUB_OUTPUT"
     - name: Build with dotnet
       env:
         VERSION: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
@@ -50,7 +66,7 @@ jobs:
         if-no-files-found: error
     outputs:
       nugetversion: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
-      prerelease: ${{ steps.gitversion.outputs.preReleaseTag != '' }}
+      prerelease: ${{ steps.gitversion.outputs.prerelease }}
 
   publish:
     needs: build
@@ -59,6 +75,10 @@ jobs:
     permissions:
       contents: write # needed to create the release
     steps:
+      # Only needed to read the tag message, which becomes the release notes.
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 0
       - name: Download build artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
@@ -82,9 +102,16 @@ jobs:
           else
             prerelease_flag=""
           fi
+          # The annotated tag message is the release notes, so they are written once
+          # when the release is tagged and travel with the tag.
+          git tag -l --format='%(contents:body)' "$TAG" > release-notes.md
+          if [ ! -s release-notes.md ]; then
+            echo "Release $VERSION" > release-notes.md
+          fi
           gh release create "$TAG" \
             --draft \
             --title "Release $VERSION" \
+            --notes-file release-notes.md \
             $prerelease_flag \
             "./Kontent.Statiq.$VERSION.nupkg" \
             "./Kontent.Statiq.$VERSION.snupkg"


### PR DESCRIPTION
My previous fix (#58) did not work. Tagging `v2.0-beta16` a second time produced `2.0.0-tags-v2-0-beta1-0001` again. The tag and draft release have been deleted, nothing reached nuget.org.

### Why the first fix failed

Setting `GITHUB_REF: refs/heads/main` on the GitVersion step has no effect. The runner log shows the override arriving and GitVersion ignoring it:

```
GITHUB_REF: refs/heads/main                                     <- our override, applied
Branch from build environment: refs/tags/v2.0-beta16            <- what GitVersion used
HEAD points at branch 'refs/heads/tags/v2.0-beta16'
```

The gittools action passes the branch to GitVersion itself, so the environment variable never gets a say. That was my mistake: I verified the GitVersion behaviour locally but assumed the action was a transparent wrapper around the CLI, and never tested that assumption.

### What actually works

Run the CLI directly with the build server integration disabled, so GitVersion uses the checked out branch instead of the ref from the build environment. `actions/checkout` leaves the workspace detached at the tag, so main is pointed at the tagged commit first.

Verified locally by reproducing exactly what the workflow does:

```
git checkout --detach v2.0-beta16      # what actions/checkout leaves behind
git checkout -B main "$GITHUB_SHA"     # the new step
env -u GITHUB_ACTIONS dotnet-gitversion /showvariable NuGetVersionV2
  -> 2.0.0-beta0016
PreReleaseTag -> beta.16
```

For contrast, the same clone without those two steps:

| Setup | Result |
| --- | --- |
| detached at tag, build server integration on | `2.0.0-tags-v2-0-beta1-0001` |
| detached at tag, integration off | `2.0.0--no-branch-0001` |
| **on main, integration off** | **`2.0.0-beta0016`** |

### A guard, so this cannot happen a third time

The version step now fails the build if the calculated version still looks like a branch name:

```sh
case "$version" in
  *tags-*|*no-branch*) echo "Refusing to release with version '$version'" >&2; exit 1 ;;
esac
```

Both previous bad releases would have stopped here instead of building a package and creating a draft release.

### Release notes come from the tag

The annotated tag message is now used as the release notes via `--notes-file`, so the notes are written once when the release is tagged and travel with the tag rather than being filled in by hand afterwards. The publish job gains a checkout step to read the tag message.

### ci.yml is unchanged

It keeps using the gittools action, which is fine there: CI only runs on branch and pull request refs, where the branch from the build environment is correct. The dependabot pin from #58 still applies to it.

### How to test

Merge, push a `v*` tag, and check the draft release. The guard means a wrong version fails loudly in the build job rather than producing a package.