### PR TITLE
Download assets over a pooled, retrying HTTP client

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ Repo: https://github.com/alanta/Kontent.Statiq · License: MIT · Package: `Kont
 | --- | --- |
 | `Kontent.Statiq/` | The library. This is the shipped NuGet package. |
 | `Kontent.Statiq.Tests/` | xUnit test project. |
+| `docs/` | Design notes explaining *why* something is built the way it is, for decisions that look like they could be simplified away. Not user-facing docs — those go in `README.md`. |
 | `.github/workflows/` | `ci.yml` (build+test on push), `release.yml` (tag `v*` → draft GitHub release), `publish.yml` (release published → push to nuget.org). |
 | `GitVersion.yml` | Version is derived from git history by GitVersion — never hard-code a version in a csproj. |
 | `README.md` | The user-facing docs *and* the NuGet package readme (`PackageReadmeFile`). Update it when public API changes. |
@@ -28,7 +29,12 @@ Ignore `obj/`, `bin/`, `.vs/`, `_NCrunch_Kontent.Statiq/` — build/IDE leftover
 - `Kontent<TContent>` / `KontentTaxonomy<TTaxonomy>` — the input modules that query the Delivery API.
 - `KontentImageProcessor` — rewrites asset URLs in rendered HTML to local paths and records the
   needed downloads in document metadata under `KontentKeys.Images.Downloads`.
-- `KontentDownloadImages` — reads that metadata and fetches the assets (wraps Statiq's `ReadWeb`).
+- `KontentDownloadImages` — reads that metadata and fetches the assets, in batches of 20, caching
+  results so a preview re-render doesn't download everything again.
+- `ReadWebAssets` — internal; the actual downloader. Deliberately *not* Statiq's `ReadWeb`, which
+  leaks sockets and writes throttling error pages to disk as image content. It only does anonymous
+  GETs and can never do more, because `WebRequestHeaders.ApplyTo` is internal to `Statiq.Core`.
+  Read [docs/asset-downloads.md](docs/asset-downloads.md) before changing either module.
 - `KontentAssetHelper` — url → local filename mapping (query string is hashed into the name).
 - `TypedContentExtensions`, `KontentDocumentHelpers`, `Html/HtmlHelpers` — helpers for Razor views.
 
@@ -43,7 +49,7 @@ dotnet build Kontent.Statiq.sln -c Debug
 dotnet test Kontent.Statiq.sln -c Debug --no-build
 ```
 
-Expected: build succeeds with warnings only; all tests pass (41 as of the last check).
+Expected: build succeeds with warnings only; all tests pass (43 as of the last check).
 
 If only a newer SDK/runtime is installed, the build still works (targeting packs come from NuGet)
 but the test host will not start. Either install the .NET 8 runtime or run the tests with
@@ -87,7 +93,13 @@ whose entire content then shows up as modified.
 - `TestExecutionContext` is a test double, not the real `Engine`, so engine-level behaviour is not
   exercised — notably it never calls `IConcurrentCache.ResetCaches()`. A cache registered as
   `resettable` therefore looks like it survives between executions in tests when it would not in a
-  real build. Check such assumptions against the Statiq source, not just a green test run.
+  real build. `TestEngine.SendHttpRequestWithRetryAsync` is a second instance of the same trap: it
+  is a plain `SendAsync` with the retry policy stripped out, so a test written against it passes
+  whether or not retry works. Check such assumptions against the Statiq source, not just a green
+  test run.
+- A test that expects a failure has to raise `TestExecutionContext.TestLoggerProvider.ThrowLogLevel`
+  first — anything logged at `Warning` or above otherwise becomes an exception before the assertions
+  run. See `When_downloading_images.cs`.
 - `Nullable` is enabled in both projects — keep annotations correct rather than sprinkling `!`.
 - Public API needs XML doc comments (`GenerateDocumentationFile` is on; missing docs warn).
 - Modules can be executed concurrently by Statiq across documents — **any shared state in a module

--- a/Kontent.Statiq.Tests/When_downloading_images.cs
+++ b/Kontent.Statiq.Tests/When_downloading_images.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using Microsoft.Extensions.Logging;
 using Statiq.Common;
 using Statiq.Core;
 using Statiq.Testing;
@@ -102,6 +103,36 @@ namespace Kontent.Statiq.Tests
             server.RequestCount.Should().Be(1);
         }
 
+        [Fact]
+        public async Task It_should_retry_a_throttled_request()
+        {
+            // Arrange
+            var server = new FakeAssetServer { FailuresBeforeSuccess = 2, FailureStatus = HttpStatusCode.TooManyRequests };
+            var pipeline = CreatePipeline(new KontentImageDownload(ImageUrl, new NormalizedPath("img/icon.png")));
+
+            // Act
+            var results = await Execute(server, pipeline);
+
+            // Assert
+            results.Should().HaveCount(1);
+            (await results[0].GetContentBytesAsync()).Should().Equal(ImageData);
+            server.RequestCount.Should().Be(3, "the two throttled responses should have been retried");
+        }
+
+        [Fact]
+        public async Task It_should_not_write_an_error_response_to_the_asset()
+        {
+            // Arrange
+            var server = new FakeAssetServer { FailuresBeforeSuccess = int.MaxValue, FailureStatus = HttpStatusCode.NotFound };
+            var pipeline = CreatePipeline(new KontentImageDownload(ImageUrl, new NormalizedPath("img/icon.png")));
+
+            // Act
+            var results = await Execute(server, pipeline, throwLogLevel: LogLevel.None);
+
+            // Assert
+            results.Should().BeEmpty("a failed download must not be written to disk under the asset name");
+        }
+
         private static IModule[] CreatePipeline(params KontentImageDownload[] downloads) => new IModule[]
         {
             new ReplaceDocuments(Config.FromContext(ctx => ctx.CreateDocument(WithDownloads(downloads)).Yield())),
@@ -114,11 +145,19 @@ namespace Kontent.Statiq.Tests
         };
 
         private static Task<ImmutableArray<IDocument>> Execute(FakeAssetServer server, params IModule[] modules)
+            => Execute(server, modules, LogLevel.Warning);
+
+        /// <param name="throwLogLevel">
+        /// Raise this when the test expects a failed download, otherwise the harness turns the
+        /// logged error into an exception before the assertions run.
+        /// </param>
+        private static Task<ImmutableArray<IDocument>> Execute(FakeAssetServer server, IModule[] modules, LogLevel throwLogLevel)
         {
             var context = new TestExecutionContext
             {
                 HttpResponseFunc = (request, _) => server.Respond(request)
             };
+            context.TestLoggerProvider.ThrowLogLevel = throwLogLevel;
             return context.ExecuteModulesAsync(modules);
         }
 
@@ -129,12 +168,24 @@ namespace Kontent.Statiq.Tests
         private sealed class FakeAssetServer
         {
             private readonly ConcurrentBag<string> _requests = new();
+            private int _failuresServed;
 
             public int RequestCount => _requests.Count;
+
+            /// <summary>How many requests to reject before serving the image, to exercise the retry policy.</summary>
+            public int FailuresBeforeSuccess { get; init; }
+
+            public HttpStatusCode FailureStatus { get; init; } = HttpStatusCode.TooManyRequests;
 
             public HttpResponseMessage Respond(HttpRequestMessage request)
             {
                 _requests.Add(request.RequestUri!.ToString());
+
+                if (_failuresServed < FailuresBeforeSuccess)
+                {
+                    _failuresServed++;
+                    return new HttpResponseMessage(FailureStatus) { Content = new System.Net.Http.StringContent("<html>nope</html>") };
+                }
 
                 var content = new ByteArrayContent(ImageData);
                 content.Headers.ContentType = new MediaTypeHeaderValue(MediaTypes.Png);

--- a/Kontent.Statiq/KontentDownloadImages.cs
+++ b/Kontent.Statiq/KontentDownloadImages.cs
@@ -43,13 +43,14 @@ namespace Kontent.Statiq
                 context.LogInformation(null, $"Downloading {newAssets.Length} files, skipping {assets.Length-newAssets.Length} already downloaded.");
             }
 
-            var childModules = newAssets.Select(a => a.OriginalUrl).Chunk(20).Select( x => new ReadWeb(x.ToArray()) );
+            var childModules = newAssets.Select(a => a.OriginalUrl).Chunk(20).Select( x => new ReadWebAssets(x.ToArray()) );
 
 
             var downloads = new List<IDocument>();
 
-            // Workaround for unlimited concurrency in ReadWeb. By fetching chunks of 20 images we prevent timeouts 
-            // caused by flooding the Kontent Delivery API with 100s of concurrent requests.
+            // ReadWebAssets retries throttled requests, but it still fetches its whole batch in parallel.
+            // Fetching chunks of 20 keeps us from flooding the Kontent Delivery API with 100s of
+            // concurrent requests and backing off on all of them at once.
             foreach (var module in childModules)
             {
                 var documents = await module!.ExecuteAsync(context);

--- a/Kontent.Statiq/ReadWebAssets.cs
+++ b/Kontent.Statiq/ReadWebAssets.cs
@@ -47,11 +47,11 @@ namespace Kontent.Statiq
                 uri => GetResponseAsync(uri, client, context), context.CancellationToken);
 
             return responses
-                .Where(response => response is object)
+                .OfType<WebResponse>()
                 .Select(response => context.CreateDocument(
                     new MetadataItems
                     {
-                        { Keys.SourceUri, response!.Uri },
+                        { Keys.SourceUri, response.Uri },
                         { Keys.SourceHeaders, response.Headers }
                     },
                     context.GetContentProvider(response.Data, response.MediaType)))
@@ -69,7 +69,8 @@ namespace Kontent.Statiq
                 {
                     // Passing the response body on would write the error page to disk under the
                     // asset's name, so drop it and let the build fail on the logged error instead.
-                    context.LogError($"Failed to download {uri} : {(int)response.StatusCode} {response.StatusCode}");
+                    context.LogError("Failed to download {Uri} : {StatusCode} {StatusName}",
+                        uri, (int)response.StatusCode, response.StatusCode);
                     return null;
                 }
 
@@ -87,7 +88,7 @@ namespace Kontent.Statiq
             }
             catch (Exception ex)
             {
-                context.LogError($"Failed to download {uri} : {ex}");
+                context.LogError(ex, "Failed to download {Uri}", uri);
                 throw;
             }
         }

--- a/Kontent.Statiq/ReadWebAssets.cs
+++ b/Kontent.Statiq/ReadWebAssets.cs
@@ -86,10 +86,17 @@ namespace Kontent.Statiq
 
                 return new WebResponse(new Uri(uri), data, content.Headers.ContentType?.MediaType, headers);
             }
+            catch (OperationCanceledException) when (context.CancellationToken.IsCancellationRequested)
+            {
+                // The execution is being torn down, not a download failure.
+                throw;
+            }
             catch (Exception ex)
             {
+                // A failure that outlived the retries is handled the same way as a non-success
+                // status: drop the document and let the build fail on the logged error.
                 context.LogError(ex, "Failed to download {Uri}", uri);
-                throw;
+                return null;
             }
         }
 

--- a/Kontent.Statiq/ReadWebAssets.cs
+++ b/Kontent.Statiq/ReadWebAssets.cs
@@ -1,0 +1,97 @@
+using Microsoft.Extensions.Logging;
+using Statiq.Common;
+using Statiq.Core;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Kontent.Statiq
+{
+    /// <summary>
+    /// Downloads the given URIs and outputs the responses as new documents.
+    /// </summary>
+    /// <remarks>
+    /// This is a narrowed stand-in for <c>Statiq.Core.ReadWeb</c>, which builds and disposes a fresh
+    /// <see cref="HttpClientHandler"/> for every single request and never retries. Downloading a few
+    /// hundred assets that way runs out of sockets, and the first 429 the Delivery API returns ends up
+    /// written to disk as if it were image content.
+    ///
+    /// This module instead takes one client from <see cref="IExecutionState.CreateHttpClient()"/> per
+    /// execution — that overload reuses the engine's shared message handler — and sends through
+    /// <c>SendWithRetryAsync</c>, which retries 429s and transient socket failures with exponential
+    /// back-off. <c>IExecutionState.SendHttpRequestWithRetryAsync</c> would do the same, but its
+    /// <c>TestEngine</c> implementation skips the retry policy, so the behaviour could not be covered
+    /// by tests.
+    ///
+    /// Only anonymous GETs are supported: request headers and credentials are out of reach because
+    /// <c>WebRequestHeaders.ApplyTo</c> is internal to Statiq.Core. Use <c>Statiq.Core.ReadWeb</c> when
+    /// you need those.
+    /// </remarks>
+    internal sealed class ReadWebAssets : Module
+    {
+        private readonly string[] _uris;
+
+        public ReadWebAssets(params string[] uris)
+        {
+            _uris = uris.ThrowIfNull(nameof(uris));
+        }
+
+        /// <inheritdoc />
+        protected override async Task<IEnumerable<IDocument>> ExecuteContextAsync(IExecutionContext context)
+        {
+            using var client = context.CreateHttpClient();
+            var responses = await _uris.ParallelSelectAsync(
+                uri => GetResponseAsync(uri, client, context), context.CancellationToken);
+
+            return responses
+                .Where(response => response is object)
+                .Select(response => context.CreateDocument(
+                    new MetadataItems
+                    {
+                        { Keys.SourceUri, response!.Uri },
+                        { Keys.SourceHeaders, response.Headers }
+                    },
+                    context.GetContentProvider(response.Data, response.MediaType)))
+                .ToArray();
+        }
+
+        private static async Task<WebResponse?> GetResponseAsync(string uri, HttpClient client, IExecutionContext context)
+        {
+            try
+            {
+                using var response = await client.SendWithRetryAsync(
+                    () => new HttpRequestMessage(HttpMethod.Get, uri), context.CancellationToken);
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    // Passing the response body on would write the error page to disk under the
+                    // asset's name, so drop it and let the build fail on the logged error instead.
+                    context.LogError($"Failed to download {uri} : {(int)response.StatusCode} {response.StatusCode}");
+                    return null;
+                }
+
+                using var content = response.Content;
+
+                // The response is disposed on the way out of this method while the content provider is
+                // only read later on, so the body has to be buffered here either way.
+                var data = await content.ReadAsByteArrayAsync(context.CancellationToken);
+
+                var headers = content.Headers.ToDictionary(
+                    x => CultureInfo.CurrentCulture.TextInfo.ToTitleCase(x.Key),
+                    x => string.Join(",", x.Value));
+
+                return new WebResponse(new Uri(uri), data, content.Headers.ContentType?.MediaType, headers);
+            }
+            catch (Exception ex)
+            {
+                context.LogError($"Failed to download {uri} : {ex}");
+                throw;
+            }
+        }
+
+        private sealed record WebResponse(Uri Uri, byte[] Data, string? MediaType, Dictionary<string, string> Headers);
+    }
+}

--- a/docs/asset-downloads.md
+++ b/docs/asset-downloads.md
@@ -1,0 +1,86 @@
+# Why asset downloads don't use `Statiq.Core.ReadWeb`
+
+`KontentDownloadImages` fetches assets through an internal module, [`ReadWebAssets`](../Kontent.Statiq/ReadWebAssets.cs),
+rather than Statiq's own `ReadWeb`. This note records why, so the next person to read that code
+doesn't "simplify" it back.
+
+## The problem
+
+A content-heavy site references hundreds of Kontent.ai assets. Downloading them through `ReadWeb`
+was unreliable: builds intermittently failed, and worse, sometimes *succeeded* while writing broken
+images.
+
+Two independent causes, both in `Statiq.Core.ReadWeb`:
+
+**A fresh handler per request.** `ReadWeb.GetResponseAsync` does this for every single URL:
+
+```csharp
+using HttpClientHandler clientHandler = new HttpClientHandler();
+using HttpClient client = context.CreateHttpClient(clientHandler);
+```
+
+Each request gets its own connection pool, and disposal leaves the socket in `TIME_WAIT`. A few
+hundred assets exhausts the ephemeral port range. Note that the *parameterless*
+`IExecutionState.CreateHttpClient()` overload does the right thing already — it hands out a client
+over the engine's shared message handler with `disposeHandler: false`. `ReadWeb` opts out of it only
+so it can attach `request.Credentials` to a per-request handler.
+
+**No retry, and no status check.** `ReadWeb` never inspects `IsSuccessStatusCode`. When the Delivery
+API throttles and returns `429`, the response body — an error page — is handed on as document content
+and written to disk under the asset's filename. You get a `.jpg` containing HTML, and a green build.
+
+## What `ReadWebAssets` does instead
+
+Statiq already ships the machinery for both halves; `ReadWeb` just doesn't use it.
+
+- One client per module execution from `context.CreateHttpClient()` — the shared-handler overload.
+- Requests go through `Statiq.Core.HttpClientExtensions.SendWithRetryAsync`, a Polly policy: 5
+  attempts, exponential back-off, triggered by `429`, `HttpRequestException`, and `TaskCanceledException`
+  wrapping an `IOException`/`SocketException`.
+- A non-2xx response that survives the retries is logged as an error and the document is **dropped**,
+  so a failed download can never be written out under the asset's name.
+- `context.CancellationToken` is threaded through the parallel select, the send, and the body read.
+
+`KontentDownloadImages` still chunks URLs into batches of 20 and awaits each batch. Retry limits the
+damage from throttling but does nothing to limit concurrency, and backing off on 300 simultaneous
+requests is far worse than not making them. The two mechanisms are complementary.
+
+## Why it isn't a general-purpose `ReadWeb` replacement
+
+`ReadWebAssets` only does anonymous `GET`s. It is `internal` and should stay that way.
+
+`WebRequestHeaders.ApplyTo(HttpRequestHeaders)` — the only way to apply a `WebRequestHeaders` to a
+request — is `internal` to `Statiq.Core`. **No out-of-tree copy of `ReadWeb` can support request
+headers or credentials.** Anything needing those must keep using `Statiq.Core.ReadWeb`.
+
+That constraint is also the argument for fixing this upstream rather than growing this module: the
+general-purpose version can only live in `Statiq.Core`. If you pick that up, the change there is
+small — use the parameterless `CreateHttpClient()` unless `Credentials` is set, send via
+`SendWithRetryAsync`, and pass the cancellation token to `ParallelSelectAsync`/`ReadAsStreamAsync`/`CopyToAsync`.
+Whether a non-2xx should fail the build is a separate and more contentious question, worth raising as
+its own issue. As of this writing there is no open Statiq issue covering any of it.
+
+## Testing note
+
+The obvious seam, `IExecutionState.SendHttpRequestWithRetryAsync`, is **not testable**:
+`Statiq.Testing.TestEngine` implements it as a plain `SendAsync` with no retry policy, so a test
+against it passes whether or not retry works. Going through `CreateHttpClient()` +
+`SendWithRetryAsync` exercises the real policy under `TestExecutionContext`, because only the message
+handler is faked.
+
+`When_downloading_images.cs` covers both behaviours: `It_should_retry_a_throttled_request` asserts the
+fake server saw exactly 3 requests, and `It_should_not_write_an_error_response_to_the_asset` asserts a
+persistent `404` produces no document. The second test has to raise
+`TestLoggerProvider.ThrowLogLevel`, because the harness otherwise turns the logged error into an
+exception before the assertions run.
+
+## Buffering
+
+`ReadWebAssets` reads the body with `ReadAsByteArrayAsync` and passes the array to
+`context.GetContentProvider(byte[], mediaType)`, which wraps it directly in a `MemoryContent`.
+
+Buffering is unavoidable — the `HttpResponseMessage` is disposed while the content provider is only
+read later in the pipeline. But the `MemoryStreamFactory` + `CopyToAsync` dance that `ReadWeb` uses
+(and which this module used at first) buys nothing here: the `Stream` overload of
+`GetContentProvider` re-buffers anyway, and `KontentDownloadImages` immediately calls
+`GetContentBytesAsync()` to populate its cache, so a `byte[]` is materialized regardless.


### PR DESCRIPTION
## Problem

Downloading a few hundred Kontent.ai assets through `Statiq.Core.ReadWeb` is unreliable, for two independent reasons — both in `ReadWeb` itself:

**A fresh handler per request.** `ReadWeb.GetResponseAsync` news up an `HttpClientHandler` for every single URL and disposes it. Each request gets its own connection pool and leaves a socket in `TIME_WAIT`; a few hundred assets exhausts the ephemeral port range. `ReadWeb` opts out of the parameterless `CreateHttpClient()` overload — which already uses the engine's shared handler with `disposeHandler: false` — only so it can attach `request.Credentials`.

**No retry, no status check.** `ReadWeb` never inspects `IsSuccessStatusCode`. When the Delivery API throttles, the `429` body is handed on as document content and written to disk under the asset's filename: a `.jpg` full of HTML, and a green build.

## Change

Statiq already ships what's needed for both halves. New internal `ReadWebAssets` module:

- one client per execution from `context.CreateHttpClient()` (shared message handler)
- sends via `Statiq.Core.HttpClientExtensions.SendWithRetryAsync` — Polly, 5 attempts, exponential back-off on `429`, `HttpRequestException`, and socket/IO `TaskCanceledException`
- a non-2xx surviving the retries is logged as an error and the document **dropped**, so a failed download can't be written out under the asset's name
- `context.CancellationToken` threaded through the parallel select, the send, and the body read

`KontentDownloadImages` keeps its batches of 20. Retry limits the damage from throttling but doesn't limit concurrency, and backing off on 300 simultaneous requests is worse than not making them.

## Why this isn't a general-purpose `ReadWeb` replacement

`ReadWebAssets` is `internal` and GET-only, and can't become more. `WebRequestHeaders.ApplyTo` is `internal` to `Statiq.Core`, so **no out-of-tree copy of `ReadWeb` can support request headers or credentials.** That constraint is also the argument for eventually fixing this upstream — the general version can only live in `Statiq.Core`. `docs/asset-downloads.md` sketches what that change would be.

## Testing note

`IExecutionState.SendHttpRequestWithRetryAsync` is the obvious seam and is **not testable** — `TestEngine` implements it as a plain `SendAsync` with the retry policy stripped, so a test against it passes whether or not retry works. Going through `CreateHttpClient()` + `SendWithRetryAsync` exercises the real policy, since only the message handler is faked.

Two new tests: `It_should_retry_a_throttled_request` asserts the fake server saw exactly 3 requests; `It_should_not_write_an_error_response_to_the_asset` asserts a persistent 404 yields no document.

## Verification

```
dotnet build Kontent.Statiq.sln -c Debug      # Build succeeded, no CS warnings
dotnet test Kontent.Statiq.sln -c Debug --no-build
# Passed! - Failed: 0, Passed: 43, Skipped: 0, Total: 43
```

## Security checklist

No workflow changes, no dependency changes (no new `PackageReference`; the repo has no lock files or `Directory.Packages.props` to regenerate). No credentials in source or fixtures. Nothing security-relevant weakened — dropping unverified response bodies instead of writing them to disk is a tightening.

## Docs

`docs/` is new — design notes for decisions that look simplifiable but aren't. `AGENTS.md` gains the `docs/` row, the corrected module descriptions, the updated test count, and the two `TestExecutionContext` traps hit here.
